### PR TITLE
Add `alignment` field to the `H264.RemoteStream` caps

### DIFF
--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -28,18 +28,14 @@ defmodule Membrane.H264 do
   @type framerate_t :: {frames :: pos_integer, seconds :: pos_integer}
 
   @typedoc """
-  Describes h264 stream format.
+  Describes h264 NALu format.
 
-  `:anexb` (defined in Annex B of [ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
+  `:annex_b` (defined in Annex B of [ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
   is suitable for writing to a file or streaming with MPEG-TS.
   In this format each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
   that helps to identify boundaries.
-
-  `:length_prefix` is described by ISO/IEC 14496-15. In such stream NALUs lack the start codes,
-  but are preceded with their length. `:length_prefix` streams are more suitable for placing in containers
-  (e.g. they are used by QuickTime (.mov), MP4, Matroska and FLV).
   """
-  @type nalu_format_t :: :anexb | :length_prefix
+  @type nalu_format_t :: :annex_b
 
   @typedoc """
   Describes whether and how buffers are aligned.

--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -34,8 +34,12 @@ defmodule Membrane.H264 do
   is suitable for writing to a file or streaming with MPEG-TS.
   In this format each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
   that helps to identify boundaries.
+
+  `:length_prefix` is described by ISO/IEC 14496-15. In such stream NALUs lack the start codes,
+  but are preceded with their length. `:length_prefix` streams are more suitable for placing in containers
+  (e.g. they are used by QuickTime (.mov), MP4, Matroska and FLV).
   """
-  @type nalu_format_t :: :annex_b
+  @type nalu_format_t :: :annex_b | :length_prefix
 
   @typedoc """
   Describes whether and how buffers are aligned.

--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -28,20 +28,6 @@ defmodule Membrane.H264 do
   @type framerate_t :: {frames :: pos_integer, seconds :: pos_integer}
 
   @typedoc """
-  Describes h264 NALu format.
-
-  `:annex_b` (defined in Annex B of [ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
-  is suitable for writing to a file or streaming with MPEG-TS.
-  In this format each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
-  that helps to identify boundaries.
-
-  `:length_prefix` is described by ISO/IEC 14496-15. In such stream NALUs lack the start codes,
-  but are preceded with their length. `:length_prefix` streams are more suitable for placing in containers
-  (e.g. they are used by QuickTime (.mov), MP4, Matroska and FLV).
-  """
-  @type nalu_format_t :: :annex_b | :length_prefix
-
-  @typedoc """
   Describes whether and how buffers are aligned.
 
   `:au` means each buffer contains one Access Unit - all the NAL units required to decode
@@ -79,16 +65,25 @@ defmodule Membrane.H264 do
           | :high_422_intra
           | :high_444_intra
 
+  @typedoc """
+  Format definition for H264 video stream.
+
+  Regardless of the `alignment` value, NAL units are always in the Annex B format.
+
+  In Annex B (defined in ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
+  each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
+  that helps to identify boundaries.
+  Annex B is suitable for writing to a file or streaming with MPEG-TS.
+  """
   @type t :: %__MODULE__{
           width: width_t(),
           height: height_t(),
           framerate: framerate_t(),
-          nalu_format: nalu_format_t(),
           alignment: alignment_t(),
           nalu_in_metadata?: nalu_in_metadata_t(),
           profile: profile_t()
         }
 
-  @enforce_keys [:width, :height, :framerate, :nalu_format, :profile]
+  @enforce_keys [:width, :height, :framerate, :profile]
   defstruct @enforce_keys ++ [alignment: :au, nalu_in_metadata?: false]
 end

--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -30,18 +30,16 @@ defmodule Membrane.H264 do
   @typedoc """
   Describes h264 stream format.
 
-  Byte-stream format (often reffered to as 'Annex B' because it is defined in Annex B
-  of [ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
-  is suitable for writing to file or streaming with MPEG-TS.
+  `:anexb` (defined in Annex B of [ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
+  is suitable for writing to a file or streaming with MPEG-TS.
   In this format each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
   that helps to identify boundaries.
 
-  avc1 and avc3 are described by ISO/IEC 14496-15. In such stream NALUs lack the start codes,
-  but are preceded with their length. Avc streams are more suitable for placing in containers
-  (e.g. they are used by QuickTime (.mov), MP4, Matroska and FLV). Avc1 and avc3 differ in how PPS and SPS
-  (Picture Parameter Set and Sequence Parameter Set) are transported.
+  `:length_prefix` is described by ISO/IEC 14496-15. In such stream NALUs lack the start codes,
+  but are preceded with their length. `:length_prefix` streams are more suitable for placing in containers
+  (e.g. they are used by QuickTime (.mov), MP4, Matroska and FLV).
   """
-  @type stream_format_t :: :avc1 | :avc3 | :byte_stream
+  @type nalu_format_t :: :anexb | :length_prefix
 
   @typedoc """
   Describes whether and how buffers are aligned.
@@ -49,12 +47,10 @@ defmodule Membrane.H264 do
   `:au` means each buffer contains one Access Unit - all the NAL units required to decode
   a single frame of video
 
-  `:nal` aligned stream ensures that no NAL unit is split between buffers, but it is possible that
+  `:nalu` aligned stream ensures that no NAL unit is split between buffers, but it is possible that
   NALUs required for one frame are in different buffers
-
-  `:none` means the stream hasn't been parsed and is not aligned.
   """
-  @type alignment_t :: :au | :nal | :none
+  @type alignment_t :: :au | :nalu
 
   @typedoc """
   When alignment is set to `:au`, determines whether buffers have NALu info attached in metadata.
@@ -87,12 +83,12 @@ defmodule Membrane.H264 do
           width: width_t(),
           height: height_t(),
           framerate: framerate_t(),
-          stream_format: stream_format_t(),
+          nalu_format: nalu_format_t(),
           alignment: alignment_t(),
           nalu_in_metadata?: nalu_in_metadata_t(),
           profile: profile_t()
         }
 
-  @enforce_keys [:width, :height, :framerate, :stream_format, :profile]
+  @enforce_keys [:width, :height, :framerate, :nalu_format, :profile]
   defstruct @enforce_keys ++ [alignment: :au, nalu_in_metadata?: false]
 end

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -8,8 +8,8 @@ defmodule Membrane.H264.RemoteStream do
   * H264 depayloaded from an RTP stream which is always aligned to
   NAL units.
   """
-  @enforce_keys [:alignment]
-  defstruct [:decoder_configuration_record, nalu_format: :annex_b] ++ @enforce_keys
+  @enforce_keys [:alignment, :nalu_format]
+  defstruct [:decoder_configuration_record] ++ @enforce_keys
 
   @type t() :: %__MODULE__{
           alignment: Membrane.H264.alignment_t(),

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -8,8 +8,8 @@ defmodule Membrane.H264.RemoteStream do
   * H264 depayloaded from an RTP stream which is always aligned to
   NAL units.
   """
-  @enforce_keys [:alignment, :decoder_configuration_record, :nalu_format]
-  defstruct @enforce_keys
+  @enforce_keys [:alignment, :nalu_format]
+  defstruct [:decoder_configuration_record] ++ @enforce_keys
 
   @type t() :: %__MODULE__{
           alignment: Membrane.H264.alignment_t(),

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -8,8 +8,8 @@ defmodule Membrane.H264.RemoteStream do
   * H264 depayloaded from an RTP stream which is always aligned to
   NAL units.
   """
-  @enforce_keys [:alignment, :nalu_format]
-  defstruct [:decoder_configuration_record] ++ @enforce_keys
+  @enforce_keys [:alignment]
+  defstruct @enforce_keys ++ [:decoder_configuration_record]
 
   @typedoc """
   Format definition for packetized, remote H264 video streams.

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -8,8 +8,8 @@ defmodule Membrane.H264.RemoteStream do
   * H264 depayloaded from an RTP stream which is always aligned to
   NAL units.
   """
-  @enforce_keys [:alignment, :nalu_format]
-  defstruct [:decoder_configuration_record] ++ @enforce_keys
+  @enforce_keys [:alignment]
+  defstruct [:decoder_configuration_record, nalu_format: :annex_b] ++ @enforce_keys
 
   @type t() :: %__MODULE__{
           alignment: Membrane.H264.alignment_t(),

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -1,14 +1,19 @@
 defmodule Membrane.H264.RemoteStream do
   @moduledoc """
-  Format definition for H264 video streams with decoder configuration transmitted out of band.
+  Format definition for packetized, remote H264 video streams.
 
-  Example of such a stream is H264 depayloaded from a container like MP4 or FLV, where decoder configuration is signalled outside of the H264 bytestream.
+  Examples of such a stream:
+  * H264 depayloaded from a container like FLV, where
+  decoder configuration is signalled outside of the H264 bytestream.
+  * H264 depayloaded from an RTP stream which is always aligned to
+  NAL units.
   """
-  @enforce_keys [:decoder_configuration_record, :stream_format]
+  @enforce_keys [:alignment, :decoder_configuration_record, :nalu_format]
   defstruct @enforce_keys
 
   @type t() :: %__MODULE__{
-          decoder_configuration_record: binary(),
-          stream_format: Membrane.H264.stream_format_t()
+          alignment: Membrane.H264.alignment_t(),
+          decoder_configuration_record: binary() | nil,
+          nalu_format: Membrane.H264.nalu_format_t()
         }
 end

--- a/lib/membrane_h264_format/remote.ex
+++ b/lib/membrane_h264_format/remote.ex
@@ -1,6 +1,6 @@
 defmodule Membrane.H264.RemoteStream do
   @moduledoc """
-  Format definition for packetized, remote H264 video streams.
+  Module providing format definition for packetized, remote H264 video streams.
 
   Examples of such a stream:
   * H264 depayloaded from a container like FLV, where
@@ -11,9 +11,18 @@ defmodule Membrane.H264.RemoteStream do
   @enforce_keys [:alignment, :nalu_format]
   defstruct [:decoder_configuration_record] ++ @enforce_keys
 
+  @typedoc """
+  Format definition for packetized, remote H264 video streams.
+
+  Regardless of the `alignment` value, NAL units are always in the Annex B format.
+
+  In Annex B (defined in ITU-T H.264 Recommendation](http://www.itu.int/rec/T-REC-H.264-201704-I/en))
+  each NAL unit is preceded by three or four-byte start code (`0x(00)000001`)
+  that helps to identify boundaries.
+  Annex B is suitable for writing to a file or streaming with MPEG-TS.
+  """
   @type t() :: %__MODULE__{
           alignment: Membrane.H264.alignment_t(),
-          decoder_configuration_record: binary() | nil,
-          nalu_format: Membrane.H264.nalu_format_t()
+          decoder_configuration_record: binary() | nil
         }
 end


### PR DESCRIPTION
This PR introduces a new field to the `H264.RemoteStream` caps - `:alignment`. 

Besides this:
* removed `stream_format`. I couldn't find any usages of `:avc1` or `:avc3`. I believe, there is no element that sets `stream_format` to one of those values at the moment.
* removed `:none` from `:alignment` possible values. `:alignment` is also a field in plain `H264` caps which by definition represents parsed data. Therefore, there is no sense in allowing for setting `:alignment` to `:none` and describing this as stream that "hasn't been parsed and is not aligned".