### PR TITLE
Make framerate in H264 format optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ reason, just add the following line to your `deps` in the `mix.exs` and run
 `mix deps.get`.
 
 ```elixir
-{:membrane_h264_format, "~> 0.4"}
+{:membrane_h264_format, "~> 0.5"}
 ```
 ## Copyright and License
 

--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -25,7 +25,7 @@ defmodule Membrane.H264 do
 
   For example, NTSC's framerate of ~29.97 fps is represented by `{30_000, 1001}`
   """
-  @type framerate_t :: {frames :: pos_integer, seconds :: pos_integer}
+  @type framerate_t :: {frames :: pos_integer, seconds :: pos_integer} | nil
 
   @typedoc """
   Describes whether and how buffers are aligned.
@@ -84,6 +84,6 @@ defmodule Membrane.H264 do
           profile: profile_t()
         }
 
-  @enforce_keys [:width, :height, :framerate, :profile]
-  defstruct @enforce_keys ++ [alignment: :au, nalu_in_metadata?: false]
+  @enforce_keys [:width, :height, :profile]
+  defstruct @enforce_keys ++ [alignment: :au, nalu_in_metadata?: false, framerate: nil]
 end

--- a/lib/membrane_h264_format/h264.ex
+++ b/lib/membrane_h264_format/h264.ex
@@ -24,6 +24,8 @@ defmodule Membrane.H264 do
   it is described by 2 integers number of frames per timeframe in seconds.
 
   For example, NTSC's framerate of ~29.97 fps is represented by `{30_000, 1001}`
+  If the information about the framerate is not present in the stream, `nil` value
+  should be used.
   """
   @type framerate_t :: {frames :: pos_integer, seconds :: pos_integer} | nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.H264.Mixfile do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @github_url "https://github.com/membraneframework/membrane_h264_format"
 
   def project do


### PR DESCRIPTION
This PR:
* Makes the Membrane.H264 `framerate` field optional
* Sets its default value to `nil` in case that field is not passed while creating of a struct
* Bumps the version to 0.5.0

Getting rid of the required framerate field is dictated by the fact, that there are no plugins that effectively take advantage of that field (in case there are such plugins, please let me know ;) ), and setting that value for that field is problematic, as in most use cases the framerate is not fixed.